### PR TITLE
Updates for test_io.py to pass

### DIFF
--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -473,7 +473,8 @@ class Network:
                                 'clear_connectivity', 'clear_drives',
                                 'connectivity', 'copy', 'gid_to_type',
                                 'plot_cells', 'set_cell_positions',
-                                'to_dict', 'write_configuration'])
+                                'to_dict', 'write_configuration',
+                                'update_weights'])
         attrs_to_check = [x for x in all_attrs if x not in attrs_to_ignore]
 
         for attr in attrs_to_check:

--- a/hnn_core/tests/assets/jones2009_3x3_drives.json
+++ b/hnn_core/tests/assets/jones2009_3x3_drives.json
@@ -2180,7 +2180,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.006562,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2217,7 +2218,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.019482,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2284,7 +2286,8 @@
                 "A_delay": 0.1,
                 "A_weight": 7e-06,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2351,7 +2354,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.004317,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2418,7 +2422,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.1423,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2485,7 +2490,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.080074,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2522,7 +2528,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.08831,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2559,7 +2566,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.0,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2626,7 +2634,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.01525,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2693,7 +2702,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.0,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2730,7 +2740,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.19934,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2767,7 +2778,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2834,7 +2846,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.00865,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2901,7 +2914,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2938,7 +2952,8 @@
                 "A_delay": 0.1,
                 "A_weight": 3e-06,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -2975,7 +2990,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.0,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -3042,7 +3058,8 @@
                 "A_delay": 0.1,
                 "A_weight": 1.43884,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -3109,7 +3126,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.0,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -3146,7 +3164,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.008958,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -3183,7 +3202,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -3250,7 +3270,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.684013,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -3317,7 +3338,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -3447,7 +3469,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0005,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 0,
             "probability": 1.0
@@ -3577,7 +3600,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0005,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 0,
             "probability": 1.0
@@ -3707,7 +3731,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0005,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 0,
             "probability": 1.0
@@ -3837,7 +3862,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0005,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 0,
             "probability": 1.0
@@ -3904,7 +3930,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.05,
                 "lamtha": 50.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -3971,7 +3998,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.05,
                 "lamtha": 50.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4038,7 +4066,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.025,
                 "lamtha": 70.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4105,7 +4134,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.025,
                 "lamtha": 70.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4244,7 +4274,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.00025,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4383,7 +4414,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.00025,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4450,7 +4482,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.001,
                 "lamtha": 50.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4529,7 +4562,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0005,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4572,7 +4606,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.02,
                 "lamtha": 20.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4612,7 +4647,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.02,
                 "lamtha": 20.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 0,
             "probability": 1.0
@@ -4691,7 +4727,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0005,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4770,7 +4807,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.00025,
                 "lamtha": 3.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4855,7 +4893,8 @@
                 "A_delay": 0.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -4940,7 +4979,8 @@
                 "A_delay": 0.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5091,7 +5131,8 @@
                 "A_delay": 0.1,
                 "A_weight": 5.4e-05,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5242,7 +5283,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5327,7 +5369,8 @@
                 "A_delay": 0.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5412,7 +5455,8 @@
                 "A_delay": 0.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5563,7 +5607,8 @@
                 "A_delay": 1.0,
                 "A_weight": 5.4e-05,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5714,7 +5759,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5751,7 +5797,8 @@
                 "A_delay": 0.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5788,7 +5835,8 @@
                 "A_delay": 0.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5855,7 +5903,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.0008,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5922,7 +5971,8 @@
                 "A_delay": 0.1,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5959,7 +6009,8 @@
                 "A_delay": 0.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -5996,7 +6047,8 @@
                 "A_delay": 0.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -6063,7 +6115,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0075,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0
@@ -6130,7 +6183,8 @@
                 "A_delay": 1.0,
                 "A_weight": 0.0,
                 "lamtha": 100.0,
-                "threshold": 0.0
+                "threshold": 0.0,
+                "gain": 1.0
             },
             "allow_autapses": 1,
             "probability": 1.0

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -103,7 +103,8 @@ def check_equal_networks(net1, net2):
                             'connectivity', 'copy', 'gid_to_type',
                             'plot_cells', 'set_cell_positions',
                             'to_dict', 'write_configuration',
-                            'external_drives', 'external_biases'])
+                            'external_drives', 'external_biases',
+                            'update_weights'])
     attrs_to_check = [x for x in all_attrs if x not in attrs_to_ignore]
     for attr in attrs_to_check:
         check_equality(getattr(net1, attr), getattr(net2, attr),

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -104,9 +104,6 @@ def generate_test_files(jones_2009_network):
     """ Generates files used in read-in tests """
     net = jones_2009_network
     net.write_configuration(Path('.', 'assets/jones2009_3x3_drives.json'))
-    simulate_dipole(net, tstop=2, n_trials=1, dt=0.5)
-    net.write_configuration(Path('.',
-                                 'assets/jones2009_3x3_drives_simulated.json'))
 
 
 def test_eq(jones_2009_network, calcium_network):

--- a/hnn_core/tests/test_io.py
+++ b/hnn_core/tests/test_io.py
@@ -268,7 +268,8 @@ def test_conn_to_dict(jones_2009_network):
                       'nc_dict': {'A_delay': 0.1,
                                   'A_weight': 0.006562,
                                   'lamtha': 3.0,
-                                  'threshold': 0.0},
+                                  'threshold': 0.0,
+                                  'gain': 1.0},
                       'allow_autapses': 1,
                       'probability': 1.0}
 

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -913,18 +913,19 @@ def test_synaptic_gains():
     with pytest.raises(TypeError, match='must be an instance of bool'):
         net.update_weights(copy='True')
 
+    # Single argument check with copy
     net_updated = net.update_weights(e_e=2.0, copy=True)
-
-    for conn in net.connectivity:
-        assert conn['nc_dict']['gain'] == 1.0
-
     for conn in net_updated.connectivity:
         if (conn['src_type'] in e_cell_names and
                 conn['target_type'] in e_cell_names):
             assert conn['nc_dict']['gain'] == 2.0
         else:
             assert conn['nc_dict']['gain'] == 1.0
+    # Ensure that the original network gains did not change
+    for conn in net.connectivity:
+        assert conn['nc_dict']['gain'] == 1.0
 
+    # Single argument with inplace change
     net.update_weights(i_e=0.5, copy=False)
     for conn in net.connectivity:
         if (conn['src_type'] in i_cell_names and

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -934,6 +934,19 @@ def test_synaptic_gains():
         else:
             assert conn['nc_dict']['gain'] == 1.0
 
+    # Two argument check
+    net.update_weights(i_e=0.5, i_i=0.25, copy=False)
+    for conn in net.connectivity:
+        if (conn['src_type'] in i_cell_names and
+                conn['target_type'] in e_cell_names):
+            assert conn['nc_dict']['gain'] == 0.5
+        elif (conn['src_type'] in i_cell_names and
+                conn['target_type'] in i_cell_names):
+            assert conn['nc_dict']['gain'] == 0.25
+        else:
+            assert conn['nc_dict']['gain'] == 1.0
+
+
 
 class TestPickConnection:
     """Tests for the pick_connection function."""

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -947,10 +947,11 @@ def test_synaptic_gains():
         else:
             assert conn['nc_dict']['gain'] == 1.0
 
-    nb_updated = NetworkBuilder(net)
     # Check weights are altered
     def _get_weight(nb, conn_name, idx=0):
         return nb.ncs[conn_name][idx].weight[0]
+
+    nb_updated = NetworkBuilder(net)
     # i_e check
     assert (_get_weight(nb_updated, 'L2Basket_L2Pyr_gabaa') /
             _get_weight(nb_base, 'L2Basket_L2Pyr_gabaa')) == 0.5

--- a/hnn_core/tests/test_network.py
+++ b/hnn_core/tests/test_network.py
@@ -898,6 +898,7 @@ def test_network_mesh():
 def test_synaptic_gains():
     """Test synaptic gains update"""
     net = jones_2009_model()
+    nb_base = NetworkBuilder(net)
     e_cell_names = ['L2_pyramidal', 'L5_pyramidal']
     i_cell_names = ['L2_basket', 'L5_basket']
 
@@ -946,6 +947,19 @@ def test_synaptic_gains():
         else:
             assert conn['nc_dict']['gain'] == 1.0
 
+    nb_updated = NetworkBuilder(net)
+    # Check weights are altered
+    def _get_weight(nb, conn_name, idx=0):
+        return nb.ncs[conn_name][idx].weight[0]
+    # i_e check
+    assert (_get_weight(nb_updated, 'L2Basket_L2Pyr_gabaa') /
+            _get_weight(nb_base, 'L2Basket_L2Pyr_gabaa')) == 0.5
+    # i_i check
+    assert (_get_weight(nb_updated, 'L2Basket_L2Basket_gabaa') /
+            _get_weight(nb_base, 'L2Basket_L2Basket_gabaa')) == 0.25
+    # Unaltered check
+    assert (_get_weight(nb_updated, 'L2Pyr_L5Basket_ampa') /
+            _get_weight(nb_base, 'L2Pyr_L5Basket_ampa')) == 1
 
 
 class TestPickConnection:


### PR DESCRIPTION
 **Changes**
* Updated the test file jones2009_3x3_drives.json with gains in the connections
* Added gain to `test_conn_to_dict` assert statement
* Added the `update_weights` method to the attributes to ignore in of the Network class' `eq` method.
* Added test for two gain arguments 
* Added spot checking of NetworkBuilder weights to determine if weights were applied correctly