### PR TITLE
CMA code review

### DIFF
--- a/hnn_core/batch_simulate.py
+++ b/hnn_core/batch_simulate.py
@@ -126,7 +126,7 @@ class BatchSimulate(object):
         postproc=False,
         clear_cache=False,
         summary_func=None,
-        verbose=False,
+        verbose=False
     ):
         _validate_type(net, Network, "net", "Network")
         _validate_type(tstop, types="numeric", item_name="tstop")

--- a/hnn_core/optimization/general_optimization.py
+++ b/hnn_core/optimization/general_optimization.py
@@ -495,11 +495,13 @@ def _run_opt_cma(
             obj_fun_kwargs=obj_fun_kwargs,
         )
 
-    _b_obj_func = cma.BoundDomainTransform(_obj_func, constraints)  # evaluates fun only in the bounded domain
-
+    # KD: this does not seem to be working because I was getting a lot of solutions outside the bounds
+    # I think that's also why you had to add the max(0.01, ...) for sigma in set_params_opt_drives
+    # _b_obj_func = cma.BoundDomainTransform(_obj_func, constraints)  # evaluates fun only in the bounded domain
 
     sigma = 1 / (np.array(constraints[1]) - np.array(constraints[0]))
-    es = cma.CMAEvolutionStrategy(list(initial_params.values()), 1, {'tolfun': obj_fun_kwargs.get('tolfun', 0.01),
+    es = cma.CMAEvolutionStrategy(list(initial_params.values()), 1, {'bounds': constraints,
+                                                                     'tolfun': obj_fun_kwargs.get('tolfun', 0.01),
                                                                      'maxiter': max_iter,
                                                                      'popsize': obj_fun_kwargs.get('popsize', 100),
                                                                      'CMA_stds': obj_fun_kwargs.get('sigma', sigma),
@@ -510,18 +512,18 @@ def _run_opt_cma(
         es.disp()
     es.result_pretty()
 
-    # get optimized params
-    opt_params = solutions
+    # get best params
+    best_params = es.result.xbest
 
     # get objective values
     obj = [np.min(obj_values[:idx]) for idx in range(1, max_iter + 1)]
 
     # get optimized net
-    params = _update_params(initial_params, opt_params[np.argmin(obj_values[-1])])
+    params = _update_params(initial_params, best_params)
     net_ = initial_net.copy()
     set_params(net_, params)
 
-    return opt_params, obj, net_
+    return best_params, obj, net_
 
 
 def _run_opt_cobyla(

--- a/hnn_core/optimization/general_optimization.py
+++ b/hnn_core/optimization/general_optimization.py
@@ -611,8 +611,8 @@ def _run_opt_cobyla(
 def add_opt_drives(net, tstop=200, n_prox=2, n_dist=1):
     prox_cell_type = ['L5_pyramidal', 'L5_basket', 'L2_pyramidal', 'L2_basket']
     dist_cell_type = ['L5_pyramidal', 'L2_pyramidal', 'L2_basket']
-    default_range = {'mu': (0, tstop), 'sigma': (0, 20), 'ampa': (-5, 1), 'nmda': (-5, 1)}
-    default_values = {'mu': tstop // 2, 'sigma': 2, 'ampa': -3, 'nmda': -3}
+    default_range = {'mu': (0, tstop), 'sigma': (0, 20), 'numspikes':(0,1), 'ampa': (-5, 1), 'nmda': (-5, 1)}
+    #default_values = {'mu': tstop // 2, 'sigma': 2, 'numspikes':1, 'ampa': -3, 'nmda': -3}
 
     prox_weights  = {cell_type: 0.0 for cell_type in prox_cell_type}
     dist_weights  = {cell_type: 0.0 for cell_type in dist_cell_type}
@@ -629,6 +629,9 @@ def add_opt_drives(net, tstop=200, n_prox=2, n_dist=1):
 
         constraints[f'{name}_sigma'] = default_range['sigma']
         initial_params[f'{name}_sigma'] = np.random.uniform(*default_range['sigma'])
+
+        constraints[f'{name}_numspikes'] = default_range['numspikes']
+        initial_params[f'{name}_numspikes'] = 1
 
         for cell_type in prox_cell_type:
             constraints[f'{name}_{cell_type}_ampa'] = default_range['ampa']
@@ -655,6 +658,9 @@ def add_opt_drives(net, tstop=200, n_prox=2, n_dist=1):
         constraints[f'{name}_sigma'] = default_range['sigma']
         initial_params[f'{name}_sigma'] = np.random.uniform(*default_range['sigma'])
 
+        constraints[f'{name}_numspikes'] = default_range['numspikes']
+        initial_params[f'{name}_numspikes'] = 1
+
         for cell_type in prox_cell_type:
             constraints[f'{name}_{cell_type}_ampa'] = default_range['ampa']
             initial_params[f'{name}_{cell_type}_ampa'] = np.random.uniform(*default_range['ampa'])
@@ -680,12 +686,22 @@ def set_params_opt_drives(net, param_values):
         target_cell_types = net.external_drives[name]['target_types']
 
         net.external_drives[name]['dynamics']['mu'] = param_values[f'{name}_mu']
-        
-        # Very important this remains above 0.0
-        net.external_drives[name]['dynamics']['sigma'] = max(0.01, param_values[f'{name}_sigma'])
+        net.external_drives[name]['dynamics']['sigma'] = param_values[f'{name}_sigma']
+        net.external_drives[name]['dynamics']['numspikes'] = max(1, int(np.round(param_values[f'{name}_numspikes'])))
+
+        # reinstate external drives to be able to fill in below
+        for receptor in ['ampa', 'nmda']:
+                        net.external_drives[name][f'weights_{receptor}'] = {
+                        ct: 0.0 for ct in target_cell_types
+                    }
 
         for cell_type in target_cell_types:
             for receptor in ['ampa', 'nmda']:
+
                 conn_idx = pick_connection(net, src_gids=name, target_gids=cell_type, receptor=receptor)
                 assert len(conn_idx) == 1
+
+                # KD: I still think this isn't the user-friendliest way as this is pretty hidden. 
+                # Will fix.
                 net.connectivity[conn_idx[0]]['nc_dict']['A_weight'] = 10 ** param_values[f'{name}_{cell_type}_{receptor}']
+                net.external_drives[name][f'weights_{receptor}'][cell_type] = 10 ** param_values[f'{name}_{cell_type}_{receptor}']

--- a/hnn_core/optimization/objective_functions.py
+++ b/hnn_core/optimization/objective_functions.py
@@ -206,18 +206,20 @@ def _corr_evoked(
     new_net = initial_net.copy()
 
     set_params_batch = lambda a,b: set_params(b, a) # need to fix this
+    
     batch_simulation = BatchSimulate(net=new_net,
                                     set_params=set_params_batch,
                                     save_outputs=False,
                                     save_dpl=True,
+                                    dt=obj_fun_kwargs.get('dt', 0.025),
+                                    n_trials=obj_fun_kwargs.get('n_trials', 1),
                                     tstop=tstop,
-                                    dt=0.5,
                                     overwrite=False,
                                     clear_cache=False,
                                     verbose=0)
 
     res = batch_simulation.run(params_batch,
-                            n_jobs=50,
+                            n_jobs=obj_fun_kwargs.get('n_jobs', 50),
                             combinations=False,
                             backend='loky',
                             verbose=0)
@@ -225,13 +227,14 @@ def _corr_evoked(
     dpls = list()
     for batch_res in res['simulated_data']:
         for data in batch_res:
-            dpls.append(data['dpl'][0])
-
-    # smooth & scale
-    if "scale_factor" in obj_fun_kwargs:
-        [dpl.scale(obj_fun_kwargs["scale_factor"]) for dpl in dpls]
-    if "smooth_window_len" in obj_fun_kwargs:
-        [dpl.smooth(obj_fun_kwargs["smooth_window_len"]) for dpl in dpls]
+            # smooth & scale all dipoles in this population (defined by n_trials)
+            if "scale_factor" in obj_fun_kwargs:
+                [trl_dpl.scale(obj_fun_kwargs["scale_factor"]) for trl_dpl in data['dpl']]
+            if "smooth_window_len" in obj_fun_kwargs:
+                [trl_dpl.smooth(obj_fun_kwargs["smooth_window_len"]) for trl_dpl in data['dpl']]
+            
+            # average dipoles per population
+            dpls.append(average_dipoles(data['dpl']))
 
     obj = [_corr(dpl, obj_fun_kwargs["target"], tstop=tstop) for dpl in dpls]
     obj_values.append(obj)


### PR DESCRIPTION
Hey @ntolley this PR is related to my code review of your CMA PR.
I tried CMA on the new model and got it to work, but I changed a few things I noticed in the process:

* I was getting a lot of values outside the pre-defined bounds (which I believe is also why you had to hard-code the 0.01 threshold for sigma when setting parameters). Added bounds.
* The loss I got when simulating a dipole with the optimized network and comparing to the target dipole and the last value in optim.obj_ differed substantially. There were two reasons for that:
* 1. obj was tracking the best loss over all iterations but the best params of the last iteration were selected and not best params overall. This is related to Carolina's PR https://github.com/jonescompneurolab/hnn-core/pull/1240. I am now selecting the best params
* 2. dt was set to 0.5 in the objective function, and the dipole is quite a bit different when using the default dt. I have added an option for the user to set dt
* The optimization would only run over 1 trial and I have updated the code to allow optimization to an average over several trials
* As outlined in my code review, I don't think it's ideal that set_params_opt_drive didn't set the external_drives, because it will look like the synaptic weights of all drives are zero. I think this is really hard for users to interpret as we teach people to define and look for synaptic weights in external_drives. I have changed the code to update this.
* IMO, setting the weight to 10**param is great because you can explore a wide space and learning seems to happen fast, but I think it's confusing how is somewhat hidden in the code and not easy to spot by users. Could discuss at dev meeting?

I believe that the enormous speed-up you achieved was because of dt=0.5. Just running an optimization of all drives with dt=0.025 and 5 trials at a time and I got 3 iterations in 2 hours...
I still think the convergence is wonderful and the fits I got with dt=0.5 were great! Especially for a large parameter space over all drives this is super impressive!

Here is a script I used to make sure this works as intended.
[debug_cma.py](https://github.com/user-attachments/files/25138182/debug_cma.py)

Hope this is useful!